### PR TITLE
Update PyTorch 2.2.0, Scilpy 2.0.2, DWI_ML and adapt target SH order based on the training data.

### DIFF
--- a/TrackToLearn/datasets/utils.py
+++ b/TrackToLearn/datasets/utils.py
@@ -155,7 +155,7 @@ def set_sh_order_basis(
         _, orders = sph_harm_ind_list(sh_order, full_basis)
         sh = sh[..., orders % 2 == 0]
 
-    # If SH are not of order 6, convert them
+    # If SH are not of target order, convert them
     if sh_order != target_order:
         print('SH coefficients are of order {}, '
               'converting them to order {}.'.format(sh_order, target_order))

--- a/TrackToLearn/datasets/utils.py
+++ b/TrackToLearn/datasets/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from dipy.data import get_sphere
 from dipy.reconst.csdeconv import sph_harm_ind_list
 from scilpy.reconst.utils import get_sh_order_and_fullness
-from scilpy.reconst.multi_processes import convert_sh_basis
+from scilpy.reconst.sh import convert_sh_basis
 
 
 class MRIDataVolume(object):

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -12,8 +12,9 @@ from dwi_ml.data.processing.volume.interpolation import \
     interpolate_volume_in_neighborhood
 from dwi_ml.data.processing.space.neighborhood import \
     get_neighborhood_vectors_axes
-from scilpy.reconst.utils import (find_order_from_nb_coeff, get_b_matrix,
+from scilpy.reconst.utils import (find_order_from_nb_coeff,
                                   get_maximas)
+from dipy.reconst.shm import sh_to_sf_matrix
 from torch.utils.data import DataLoader
 
 from TrackToLearn.datasets.SubjectDataset import SubjectDataset
@@ -412,8 +413,7 @@ class BaseEnv(object):
         sphere = HemiSphere.from_sphere(get_sphere("repulsion724")
                                         ).subdivide(0)
 
-        b_matrix = get_b_matrix(
-            find_order_from_nb_coeff(data), sphere, "descoteaux07")
+        b_matrix, _ = sh_to_sf_matrix(sphere, find_order_from_nb_coeff(data), "descoteaux07")
 
         for idx in np.argwhere(np.sum(data, axis=-1)):
             idx = tuple(idx)

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -210,7 +210,7 @@ class BaseEnv(object):
             self.affine_vox2rasmm)
         self.neighborhood_directions = torch.cat(
             (torch.zeros((1, 3)),
-             get_neighborhood_vectors_axes(1, self.add_neighborhood_vox))
+             get_neighborhood_vectors_axes(self.add_neighborhood_vox))
         ).to(self.device)
 
         # Tracking seeds

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -385,7 +385,7 @@ class BaseEnv(object):
 
         data = set_sh_order_basis(signal.get_fdata(dtype=np.float32),
                                   sh_basis,
-                                  target_order=8,
+                                  target_order=6,
                                   target_basis='descoteaux07')
 
         # Compute peaks from signal

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -539,7 +539,8 @@ class BaseEnv(object):
         signal, _ = interpolate_volume_in_neighborhood(
             self.data_volume,
             coords,
-            self.neighborhood_directions)
+            self.neighborhood_directions,
+            clear_cache=False)
         N, S = signal.shape
 
         # Placeholder for the final imputs

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -373,7 +373,7 @@ class BaseEnv(object):
         sh_basis: str
             Basis of the SH coefficients.
         target_sh_order: int
-            Target SH order.
+            Target SH order. Should come from the hyperparameters file.
 
         Returns
         -------

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -210,7 +210,7 @@ class BaseEnv(object):
             self.affine_vox2rasmm)
         self.neighborhood_directions = torch.cat(
             (torch.zeros((1, 3)),
-             get_neighborhood_vectors_axes(self.add_neighborhood_vox))
+             get_neighborhood_vectors_axes(1, self.add_neighborhood_vox))
         ).to(self.device)
 
         # Tracking seeds

--- a/TrackToLearn/experiment/experiment.py
+++ b/TrackToLearn/experiment/experiment.py
@@ -258,7 +258,8 @@ class Experiment(object):
         tractogram,
         subject_id: str,
         affine: np.ndarray,
-        reference: nib.Nifti1Image
+        reference: nib.Nifti1Image,
+        path_prefix: str = ''
     ) -> str:
         """
         Saves a non-stateful tractogram from the training/validation
@@ -278,8 +279,9 @@ class Experiment(object):
         # Save tractogram so it can be looked at, used by the tractometer
         # and more
         filename = pjoin(
-            self.experiment_path, "tractogram_{}_{}_{}.trk".format(
-                self.experiment, self.name, subject_id))
+            path_prefix,
+            self.experiment_path,
+            "tractogram_{}_{}_{}.trk".format(self.experiment, self.name, subject_id))
 
         # Prune empty streamlines, keep only streamlines that have more
         # than the seed.
@@ -391,6 +393,7 @@ def add_experiment_args(parser: ArgumentParser):
                         help='Seed to fix general randomness')
     parser.add_argument('--use_comet', action='store_true',
                         help='Use comet to display training or not')
+    parser.add_argument('--comet_offline_dir', type=str, help='Comet offline directory. If enabled, logs will be saved to this directory and the experiment will be ran offline.')
 
 
 def add_data_args(parser: ArgumentParser):

--- a/TrackToLearn/experiment/experiment.py
+++ b/TrackToLearn/experiment/experiment.py
@@ -124,7 +124,8 @@ class Experiment(object):
             'tractometer_validator': self.tractometer_validator,
             'binary_stopping_threshold': self.binary_stopping_threshold,
             'compute_reward': self.compute_reward,
-            'device': self.device
+            'device': self.device,
+            'target_sh_order': self.target_sh_order if hasattr(self, 'target_sh_order') else None,
         }
 
         if noisy:

--- a/TrackToLearn/runners/ttl_track.py
+++ b/TrackToLearn/runners/ttl_track.py
@@ -102,6 +102,7 @@ class TrackToLearnTrack(Experiment):
             self.theta = hyperparams['max_angle']
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_dirs = hyperparams['n_dirs']
+            self.target_sh_order = hyperparams['target_sh_order']
 
         self.alignment_weighting = 0.0
         # Oracle parameters

--- a/TrackToLearn/runners/ttl_track.py
+++ b/TrackToLearn/runners/ttl_track.py
@@ -98,12 +98,10 @@ class TrackToLearnTrack(Experiment):
             hyperparams = json.load(json_file)
             self.algorithm = hyperparams['algorithm']
             self.step_size = float(hyperparams['step_size'])
-            self.add_neighborhood = hyperparams['add_neighborhood']
             self.voxel_size = hyperparams.get('voxel_size', 2.0)
             self.theta = hyperparams['max_angle']
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_dirs = hyperparams['n_dirs']
-            self.interface_seeding = hyperparams['interface_seeding']
 
         self.alignment_weighting = 0.0
         # Oracle parameters

--- a/TrackToLearn/runners/ttl_track_from_hdf5.py
+++ b/TrackToLearn/runners/ttl_track_from_hdf5.py
@@ -82,14 +82,12 @@ class TrackToLearnValidation(Experiment):
             hyperparams = json.load(json_file)
             self.algorithm = hyperparams['algorithm']
             self.step_size = float(hyperparams['step_size'])
-            self.add_neighborhood = hyperparams['add_neighborhood']
             self.voxel_size = float(hyperparams['voxel_size'])
             self.theta = hyperparams['max_angle']
             self.epsilon = hyperparams.get('max_angular_error', 90)
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_signal = hyperparams['n_signal']
             self.n_dirs = hyperparams['n_dirs']
-            self.interface_seeding = hyperparams['interface_seeding']
             self.cmc = hyperparams.get('cmc', False)
             self.binary_stopping_threshold = hyperparams.get(
                 'binary_stopping_threshold', 0.5)

--- a/TrackToLearn/trainers/sac_auto_train.py
+++ b/TrackToLearn/trainers/sac_auto_train.py
@@ -7,6 +7,7 @@ from argparse import RawTextHelpFormatter
 import comet_ml  # noqa: F401 ugh
 import torch
 from comet_ml import Experiment as CometExperiment
+from comet_ml import OfflineExperiment as CometOfflineExperiment
 
 from TrackToLearn.algorithms.sac_auto import SACAuto
 from TrackToLearn.trainers.train import (TrackToLearnTraining,
@@ -100,11 +101,20 @@ def main():
     args = parse_args()
     print(args)
 
+    offline = args.comet_offline_dir is not None
+
     # Create comet-ml experiment
-    experiment = CometExperiment(project_name=args.experiment,
-                                 workspace=args.workspace, parse_args=False,
-                                 auto_metric_logging=False,
-                                 disabled=not args.use_comet)
+    if offline:
+        experiment = CometOfflineExperiment(project_name=args.experiment,
+                                    workspace=args.workspace, parse_args=False,
+                                    auto_metric_logging=False,
+                                    disabled=not args.use_comet,
+                                    offline_directory=args.comet_offline_dir)
+    else:
+        experiment = CometExperiment(project_name=args.experiment,
+                                    workspace=args.workspace, parse_args=False,
+                                    auto_metric_logging=False,
+                                    disabled=not args.use_comet)
 
     # Create and run experiment
     sac_auto_experiment = SACAutoTrackToLearnTraining(

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -103,6 +103,7 @@ class TrackToLearnTraining(Experiment):
             "cuda" if torch.cuda.is_available() else "cpu")
 
         self.use_comet = train_dto['use_comet']
+        self.offline_comet = train_dto['offline_comet']
 
         # RNG
         torch.manual_seed(self.rng_seed)

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -154,7 +154,8 @@ class TrackToLearnTraining(Experiment):
         # These are added here because they are not known before
         self.hyperparameters.update({'input_size': self.input_size,
                                      'action_size': self.action_size,
-                                     'voxel_size': str(self.voxel_size)})
+                                     'voxel_size': str(self.voxel_size),
+                                     'target_sh_order': self.target_sh_order})
 
         directory = pjoin(self.experiment_path, "model")
         with open(
@@ -367,6 +368,8 @@ class TrackToLearnTraining(Experiment):
 
         # Voxel size
         self.voxel_size = env.get_voxel_size()
+        # SH Order (used for tracking afterwards)
+        self.target_sh_order = env.target_sh_order
 
         max_traj_length = env.max_nb_steps
 

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -103,7 +103,6 @@ class TrackToLearnTraining(Experiment):
             "cuda" if torch.cuda.is_available() else "cpu")
 
         self.use_comet = train_dto['use_comet']
-        self.offline_comet = train_dto['offline_comet']
 
         # RNG
         torch.manual_seed(self.rng_seed)

--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,10 @@ if [ -x "$(command -v nvidia-smi)" ]; then
     echo "Found CUDA version: $(nvidia-smi | grep "CUDA Version" | awk '{print $9}')"
     # Check CUDA version and format as cuXXX
     FOUND_CUDA=$(nvidia-smi | grep "CUDA Version" | awk '{print $9}' | sed 's/\.//g')
-    if (( $FOUND_CUDA == 116 )); then
-        CUDA_VERSION="cu116"
-    elif (( $FOUND_CUDA >= 117 )); then
-        CUDA_VERSION="cu117"
+    if (( $FOUND_CUDA == 118 )); then
+        CUDA_VERSION="cu118"
+    elif (( $FOUND_CUDA >= 121 )); then
+        CUDA_VERSION="cu121"
     else
       CUDA_VERSION="cpu"
       echo "CUDA version ${FOUND_CUDA} is not compatible. Installing PyTorch without CUDA support."
@@ -29,13 +29,13 @@ echo "Installing required packages."
 pip install Cython==0.29.* numpy==1.23.* packaging --quiet
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Installing PyTorch 1.13.1"
-    pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 --quiet
+    echo "Installing PyTorch 2.2.0"
+    pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --quiet
 else
     # Install pytorch
-    echo "Installing PyTorch 1.13.1+${CUDA_VERSION}"
+    echo "Installing PyTorch 2.2.0+${CUDA_VERSION}"
     # Install PyTorch with CUDA support
-    pip install torch==1.13.1+${CUDA_VERSION} torchvision==0.14.1+${CUDA_VERSION} torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION} --quiet
+    pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION} --quiet
 fi
 
 # Install other required packages and modules

--- a/models/hyperparameters.json
+++ b/models/hyperparameters.json
@@ -47,5 +47,5 @@
     "input_size": 615,
     "action_size": 3,
     "voxel_size": "0.9987237",
-    "target_sh_order": 6.0
+    "target_sh_order": 8.0
 }

--- a/models/hyperparameters.json
+++ b/models/hyperparameters.json
@@ -46,5 +46,6 @@
     "replay_size": 1000000.0,
     "input_size": 615,
     "action_size": 3,
-    "voxel_size": "0.9987237"
+    "voxel_size": "0.9987237",
+    "target_sh_order": 6.0
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 comet-ml==3.39.0
-h5py==3.10.0
+h5py==3.7.0
 nibabel==5.2.0
-tqdm==4.66.4
+tqdm==4.64.0
 
-dwi-ml==0.1.0.dev0
+dwi-ml @ git+https://github.com/EmmaRenauld/dwi_ml.git@update_to_scilpy2
 scilpy==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-comet-ml==3.21.0
-h5py==3.7.0
-nibabel==4.0.2
-tqdm==4.64.1
+comet-ml==3.39.0
+h5py==3.10.0
+nibabel==5.2.0
+tqdm==4.66.4
 
-dwi-ml @ git+https://github.com/scil-vital/dwi_ml@b7ac03a5b4f2cab77bbcf000a763afa133786b04
-scilpy @ git+https://github.com/scilus/scilpy@1.5.0
+dwi-ml==0.1.0.dev0
+scilpy==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
-comet-ml==3.39.0
-h5py==3.7.0
-nibabel==5.2.0
-tqdm==4.64.0
-
-dwi-ml @ git+https://github.com/EmmaRenauld/dwi_ml.git@update_to_scilpy2
-scilpy==2.0.2
+dwi-ml @ git+https://github.com/scil-vital/dwi_ml@for_beluga_scilpy2


### PR DESCRIPTION
## PyTorch update to 2.2.0
Didn't change anything except the install.sh file to download another PyTorch version and support different CUDA versions (w.r.t. PyTorch docs). Seems to works fine.

## Scilpy 2.0.2
A few changes here and there to adapt with functions that were moved/removed from scilpy. Logic shouldn't have changed, I used the new functions as they are used in some scilpy scenarios/tests. Changing to scilpy 2.0.2 is useful since its _wheel_ is available on Compute Canada.

## DWI_ML
**IMPORTANT:** Waiting for https://github.com/scil-vital/dwi_ml/pull/234 before merging. Might have to adapt the commit hash in the requirements.txt to refer to the main once that PR is merged.

Update of DWI_ML is useful because it now uses PyTorch 2.2.0 and Scilpy 2.0.2 which is needed for Compute Canada.

## SH Order changes:
During training:
- When loading the first subject to initialize the environment, use the input_volume from that subject to extract sh_order that the model will be trained on.
- Save the sh_target_order to the hyperparameters.json file.
- I adapted the default example model's hyperparameters.json file accordingly.

During tracking/testing (with ttl_track*):
- Load the sh_target_order directly from the hyperparameters.json file. This way the networks are initialized with the input size corresponding to the one from the pretrained model.

Other:
- Also removed `self.interface_seeding = hyperparams['interface_seeding']` and `self.add_neighborhood = hyperparams['add_neighborhood']` since they didn't seem to be used anymore and they caused issues when training/tracking.