### PR TITLE
Support Metal Performance Shaders

### DIFF
--- a/TrackToLearn/algorithms/ddpg.py
+++ b/TrackToLearn/algorithms/ddpg.py
@@ -11,7 +11,7 @@ from TrackToLearn.algorithms.shared.offpolicy import ActorCritic
 from TrackToLearn.algorithms.shared.replay import OffPolicyReplayBuffer
 from TrackToLearn.algorithms.shared.utils import add_item_to_means
 from TrackToLearn.environments.env import BaseEnv
-
+from TrackToLearn.utils.torch_utils import get_device
 
 class DDPG(RLAlgorithm):
     """
@@ -44,7 +44,7 @@ class DDPG(RLAlgorithm):
         batch_size: int = 2**12,
         replay_size: int = 1e6,
         rng: np.random.RandomState = None,
-        device: torch.device = "cuda:0",
+        device: torch.device = get_device(),
     ):
         """
         Parameters

--- a/TrackToLearn/algorithms/rl.py
+++ b/TrackToLearn/algorithms/rl.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 
 from TrackToLearn.environments.env import BaseEnv
-
+from TrackToLearn.utils.torch_utils import get_device
 
 class RLAlgorithm(object):
     """
@@ -18,7 +18,7 @@ class RLAlgorithm(object):
         gamma: float = 0.99,
         batch_size: int = 10000,
         rng: np.random.RandomState = None,
-        device: torch.device = "cuda:0",
+        device: torch.device = get_device(),
     ):
         """
         Parameters

--- a/TrackToLearn/algorithms/sac.py
+++ b/TrackToLearn/algorithms/sac.py
@@ -7,7 +7,7 @@ from typing import Tuple
 from TrackToLearn.algorithms.ddpg import DDPG
 from TrackToLearn.algorithms.shared.offpolicy import SACActorCritic
 from TrackToLearn.algorithms.shared.replay import OffPolicyReplayBuffer
-
+from TrackToLearn.utils.torch_utils import get_device
 
 class SAC(DDPG):
     """
@@ -41,7 +41,7 @@ class SAC(DDPG):
         batch_size: int = 2**12,
         replay_size: int = 1e6,
         rng: np.random.RandomState = None,
-        device: torch.device = "cuda:0",
+        device: torch.device = get_device(),
     ):
         """ Initialize the algorithm. This includes the replay buffer,
         the policy and the target policy.

--- a/TrackToLearn/algorithms/sac_auto.py
+++ b/TrackToLearn/algorithms/sac_auto.py
@@ -9,7 +9,7 @@ from typing import Tuple
 from TrackToLearn.algorithms.sac import SAC
 from TrackToLearn.algorithms.shared.offpolicy import SACActorCritic
 from TrackToLearn.algorithms.shared.replay import OffPolicyReplayBuffer
-
+from TrackToLearn.utils.torch_utils import get_device
 
 LOG_STD_MAX = 2
 LOG_STD_MIN = -20
@@ -46,7 +46,7 @@ class SACAuto(SAC):
         batch_size: int = 2**12,
         replay_size: int = 1e6,
         rng: np.random.RandomState = None,
-        device: torch.device = "cuda:0",
+        device: torch.device = get_device,
     ):
         """
         Parameters

--- a/TrackToLearn/algorithms/shared/replay.py
+++ b/TrackToLearn/algorithms/shared/replay.py
@@ -2,9 +2,9 @@ import numpy as np
 import torch
 
 from typing import Tuple
+from TrackToLearn.utils.torch_utils import get_device, get_device_str
 
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = get_device()
 
 
 class OffPolicyReplayBuffer(object):
@@ -33,16 +33,25 @@ class OffPolicyReplayBuffer(object):
         self.size = 0
 
         # Buffers "filled with zeros"
+        
+        
         self.state = torch.zeros(
-            (self.max_size, state_dim), dtype=torch.float32).pin_memory()
+            (self.max_size, state_dim), dtype=torch.float32)
         self.action = torch.zeros(
-            (self.max_size, action_dim), dtype=torch.float32).pin_memory()
+            (self.max_size, action_dim), dtype=torch.float32)
         self.next_state = torch.zeros(
-            (self.max_size, state_dim), dtype=torch.float32).pin_memory()
+            (self.max_size, state_dim), dtype=torch.float32)
         self.reward = torch.zeros(
-            (self.max_size, 1), dtype=torch.float32).pin_memory()
+            (self.max_size, 1), dtype=torch.float32)
         self.not_done = torch.zeros(
-            (self.max_size, 1), dtype=torch.float32).pin_memory()
+            (self.max_size, 1), dtype=torch.float32)
+
+        if get_device_str() == "cuda":
+            self.state = self.state.pin_memory()
+            self.action = self.action.pin_memory()
+            self.next_state = self.next_state.pin_memory()
+            self.reward = self.reward.pin_memory()
+            self.not_done = self.not_done.pin_memory()
 
     def add(
         self,
@@ -112,12 +121,19 @@ class OffPolicyReplayBuffer(object):
         ind = torch.randperm(self.size, dtype=torch.long)[
             :min(self.size, batch_size)]
 
-        s = self.state.index_select(0, ind).pin_memory()
-        a = self.action.index_select(0, ind).pin_memory()
-        ns = self.next_state.index_select(0, ind).pin_memory()
-        r = self.reward.index_select(0, ind).squeeze(-1).pin_memory()
+        s = self.state.index_select(0, ind)
+        a = self.action.index_select(0, ind)
+        ns = self.next_state.index_select(0, ind)
+        r = self.reward.index_select(0, ind).squeeze(-1)
         d = self.not_done.index_select(0, ind).to(
-            dtype=torch.float32).squeeze(-1).pin_memory()
+            dtype=torch.float32).squeeze(-1)
+        
+        if get_device_str() == "cuda":
+            s = s.pin_memory()
+            a = a.pin_memory()
+            ns = ns.pin_memory()
+            r = r.pin_memory()
+            d = d.pin_memory()
 
         # Return tensors on the same device as the buffer in pinned memory
         return (s.to(device=self.device, non_blocking=True),

--- a/TrackToLearn/datasets/utils.py
+++ b/TrackToLearn/datasets/utils.py
@@ -155,7 +155,7 @@ def set_sh_order_basis(
         _, orders = sph_harm_ind_list(sh_order, full_basis)
         sh = sh[..., orders % 2 == 0]
 
-    # If SH are not of order 6, convert them
+    # If SH are not of target order, convert them
     if sh_order != target_order:
         print('SH coefficients are of order {}, '
               'converting them to order {}.'.format(sh_order, target_order))

--- a/TrackToLearn/datasets/utils.py
+++ b/TrackToLearn/datasets/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from dipy.data import get_sphere
 from dipy.reconst.csdeconv import sph_harm_ind_list
 from scilpy.reconst.utils import get_sh_order_and_fullness
-from scilpy.reconst.multi_processes import convert_sh_basis
+from scilpy.reconst.sh import convert_sh_basis
 
 
 class MRIDataVolume(object):

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -12,8 +12,9 @@ from dwi_ml.data.processing.volume.interpolation import \
     interpolate_volume_in_neighborhood
 from dwi_ml.data.processing.space.neighborhood import \
     get_neighborhood_vectors_axes
-from scilpy.reconst.utils import (find_order_from_nb_coeff, get_b_matrix,
+from scilpy.reconst.utils import (find_order_from_nb_coeff,
                                   get_maximas)
+from dipy.reconst.shm import sh_to_sf_matrix
 from torch.utils.data import DataLoader
 
 from TrackToLearn.datasets.SubjectDataset import SubjectDataset
@@ -412,8 +413,7 @@ class BaseEnv(object):
         sphere = HemiSphere.from_sphere(get_sphere("repulsion724")
                                         ).subdivide(0)
 
-        b_matrix = get_b_matrix(
-            find_order_from_nb_coeff(data), sphere, "descoteaux07")
+        b_matrix, _ = sh_to_sf_matrix(sphere, find_order_from_nb_coeff(data), "descoteaux07")
 
         for idx in np.argwhere(np.sum(data, axis=-1)):
             idx = tuple(idx)

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -34,6 +34,8 @@ from TrackToLearn.utils.utils import normalize_vectors
 
 # from dipy.io.utils import get_reference_info
 
+def collate_fn(data):
+    return data
 
 class BaseEnv(object):
     """
@@ -83,9 +85,6 @@ class BaseEnv(object):
         if type(subject_data) is str:
             self.dataset_file = subject_data
             self.split = split_id
-
-            def collate_fn(data):
-                return data
 
             self.dataset = SubjectDataset(
                 self.dataset_file, self.split)

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -210,7 +210,7 @@ class BaseEnv(object):
             self.affine_vox2rasmm)
         self.neighborhood_directions = torch.cat(
             (torch.zeros((1, 3)),
-             get_neighborhood_vectors_axes(1, self.add_neighborhood_vox))
+             get_neighborhood_vectors_axes(self.add_neighborhood_vox))
         ).to(self.device)
 
         # Tracking seeds

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -385,7 +385,7 @@ class BaseEnv(object):
 
         data = set_sh_order_basis(signal.get_fdata(dtype=np.float32),
                                   sh_basis,
-                                  target_order=8,
+                                  target_order=6,
                                   target_basis='descoteaux07')
 
         # Compute peaks from signal

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -373,7 +373,7 @@ class BaseEnv(object):
         sh_basis: str
             Basis of the SH coefficients.
         target_sh_order: int
-            Target SH order.
+            Target SH order. Should come from the hyperparameters file.
 
         Returns
         -------

--- a/TrackToLearn/environments/env.py
+++ b/TrackToLearn/environments/env.py
@@ -210,7 +210,7 @@ class BaseEnv(object):
             self.affine_vox2rasmm)
         self.neighborhood_directions = torch.cat(
             (torch.zeros((1, 3)),
-             get_neighborhood_vectors_axes(self.add_neighborhood_vox))
+             get_neighborhood_vectors_axes(1, self.add_neighborhood_vox))
         ).to(self.device)
 
         # Tracking seeds

--- a/TrackToLearn/experiment/experiment.py
+++ b/TrackToLearn/experiment/experiment.py
@@ -258,7 +258,8 @@ class Experiment(object):
         tractogram,
         subject_id: str,
         affine: np.ndarray,
-        reference: nib.Nifti1Image
+        reference: nib.Nifti1Image,
+        path_prefix: str = ''
     ) -> str:
         """
         Saves a non-stateful tractogram from the training/validation
@@ -278,8 +279,9 @@ class Experiment(object):
         # Save tractogram so it can be looked at, used by the tractometer
         # and more
         filename = pjoin(
-            self.experiment_path, "tractogram_{}_{}_{}.trk".format(
-                self.experiment, self.name, subject_id))
+            path_prefix,
+            self.experiment_path,
+            "tractogram_{}_{}_{}.trk".format(self.experiment, self.name, subject_id))
 
         # Prune empty streamlines, keep only streamlines that have more
         # than the seed.
@@ -391,6 +393,7 @@ def add_experiment_args(parser: ArgumentParser):
                         help='Seed to fix general randomness')
     parser.add_argument('--use_comet', action='store_true',
                         help='Use comet to display training or not')
+    parser.add_argument('--comet_offline_dir', type=str, help='Comet offline directory. If enabled, logs will be saved to this directory and the experiment will be ran offline.')
 
 
 def add_data_args(parser: ArgumentParser):

--- a/TrackToLearn/experiment/experiment.py
+++ b/TrackToLearn/experiment/experiment.py
@@ -124,7 +124,8 @@ class Experiment(object):
             'tractometer_validator': self.tractometer_validator,
             'binary_stopping_threshold': self.binary_stopping_threshold,
             'compute_reward': self.compute_reward,
-            'device': self.device
+            'device': self.device,
+            'target_sh_order': self.target_sh_order if hasattr(self, 'target_sh_order') else None,
         }
 
         if noisy:

--- a/TrackToLearn/oracles/oracle.py
+++ b/TrackToLearn/oracles/oracle.py
@@ -3,7 +3,10 @@ import torch
 from dipy.tracking.streamline import set_number_of_points
 
 from TrackToLearn.oracles.transformer_oracle import TransformerOracle
+from TrackToLearn.utils.torch_utils import get_device_str, get_device
+import contextlib
 
+autocast_context = torch.cuda.amp.autocast if torch.cuda.is_available() else contextlib.nullcontext
 
 class OracleSingleton:
     _self = None
@@ -15,7 +18,7 @@ class OracleSingleton:
         return cls._self
 
     def __init__(self, checkpoint: str, device: str, batch_size=4096):
-        self.checkpoint = torch.load(checkpoint)
+        self.checkpoint = torch.load(checkpoint, map_location=get_device())
 
         hyper_parameters = self.checkpoint["hyper_parameters"]
         # The model's class is saved in hparams
@@ -38,7 +41,7 @@ class OracleSingleton:
         N = len(streamlines)
         # Placeholders for input and output data
         placeholder = torch.zeros(
-            (self.batch_size, 127, 3), pin_memory=True)
+            (self.batch_size, 127, 3), pin_memory=get_device_str() == "cuda")
         result = torch.zeros((N), dtype=torch.float, device=self.device)
 
         # Get the first batch
@@ -70,7 +73,7 @@ class OracleSingleton:
                 # Put the directions in pinned memory
                 placeholder[:end-start] = torch.from_numpy(dirs)
 
-            with torch.cuda.amp.autocast():
+            with autocast_context():
                 with torch.no_grad():
                     predictions = self.model(input_data)
                     result[

--- a/TrackToLearn/runners/ttl_track.py
+++ b/TrackToLearn/runners/ttl_track.py
@@ -102,6 +102,7 @@ class TrackToLearnTrack(Experiment):
             self.theta = hyperparams['max_angle']
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_dirs = hyperparams['n_dirs']
+            self.target_sh_order = hyperparams['target_sh_order']
 
         self.alignment_weighting = 0.0
         # Oracle parameters

--- a/TrackToLearn/runners/ttl_track.py
+++ b/TrackToLearn/runners/ttl_track.py
@@ -23,6 +23,7 @@ from TrackToLearn.datasets.utils import MRIDataVolume
 
 from TrackToLearn.experiment.experiment import Experiment
 from TrackToLearn.tracking.tracker import Tracker
+from TrackToLearn.utils.torch_utils import get_device
 
 # Define the example model paths from the install folder.
 # Hackish ? I'm not aware of a better solution but I'm
@@ -79,9 +80,7 @@ class TrackToLearnTrack(Experiment):
         self.compute_reward = False
         self.render = False
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available()
-            else "cpu")
+        self.device = get_device()
 
         self.fa_map = None
         if 'fa_map_file' in track_dto:

--- a/TrackToLearn/runners/ttl_track.py
+++ b/TrackToLearn/runners/ttl_track.py
@@ -98,12 +98,10 @@ class TrackToLearnTrack(Experiment):
             hyperparams = json.load(json_file)
             self.algorithm = hyperparams['algorithm']
             self.step_size = float(hyperparams['step_size'])
-            self.add_neighborhood = hyperparams['add_neighborhood']
             self.voxel_size = hyperparams.get('voxel_size', 2.0)
             self.theta = hyperparams['max_angle']
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_dirs = hyperparams['n_dirs']
-            self.interface_seeding = hyperparams['interface_seeding']
 
         self.alignment_weighting = 0.0
         # Oracle parameters

--- a/TrackToLearn/runners/ttl_track_from_hdf5.py
+++ b/TrackToLearn/runners/ttl_track_from_hdf5.py
@@ -82,14 +82,12 @@ class TrackToLearnValidation(Experiment):
             hyperparams = json.load(json_file)
             self.algorithm = hyperparams['algorithm']
             self.step_size = float(hyperparams['step_size'])
-            self.add_neighborhood = hyperparams['add_neighborhood']
             self.voxel_size = float(hyperparams['voxel_size'])
             self.theta = hyperparams['max_angle']
             self.epsilon = hyperparams.get('max_angular_error', 90)
             self.hidden_dims = hyperparams['hidden_dims']
             self.n_signal = hyperparams['n_signal']
             self.n_dirs = hyperparams['n_dirs']
-            self.interface_seeding = hyperparams['interface_seeding']
             self.cmc = hyperparams.get('cmc', False)
             self.binary_stopping_threshold = hyperparams.get(
                 'binary_stopping_threshold', 0.5)

--- a/TrackToLearn/runners/ttl_track_from_hdf5.py
+++ b/TrackToLearn/runners/ttl_track_from_hdf5.py
@@ -23,7 +23,7 @@ from TrackToLearn.experiment.experiment import (
     add_tractometer_args)
 from TrackToLearn.tracking.tracker import Tracker
 from TrackToLearn.experiment.experiment import Experiment
-
+from TrackToLearn.utils.torch_utils import get_device
 
 class TrackToLearnValidation(Experiment):
     """ TrackToLearn validing script. Should work on any model trained with a
@@ -98,8 +98,7 @@ class TrackToLearnValidation(Experiment):
 
         self.comet_experiment = None
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
+        self.device = get_device()
 
         self.random_seed = valid_dto['rng_seed']
         torch.manual_seed(self.random_seed)

--- a/TrackToLearn/searchers/sac_auto_searcher.py
+++ b/TrackToLearn/searchers/sac_auto_searcher.py
@@ -5,9 +5,9 @@ import torch
 from TrackToLearn.trainers.sac_auto_train import (
     parse_args,
     SACAutoTrackToLearnTraining)
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-assert torch.cuda.is_available()
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
+device = get_device()
+assert_accelerator()
 
 
 def main():

--- a/TrackToLearn/searchers/sac_auto_searcher_oracle.py
+++ b/TrackToLearn/searchers/sac_auto_searcher_oracle.py
@@ -5,9 +5,9 @@ import torch
 from TrackToLearn.trainers.sac_auto_train import (
     parse_args,
     SACAutoTrackToLearnTraining)
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-assert torch.cuda.is_available()
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
+device = get_device()
+assert_accelerator()
 
 
 def main():

--- a/TrackToLearn/trainers/ddpg_train.py
+++ b/TrackToLearn/trainers/ddpg_train.py
@@ -9,9 +9,10 @@ from comet_ml import Experiment as CometExperiment
 from TrackToLearn.algorithms.ddpg import DDPG
 from TrackToLearn.experiment.train import (
     add_training_args, TrackToLearnTraining)
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-assert torch.cuda.is_available()
+device = get_device()
+assert_accelerator()
 
 
 class DDPGTrackToLearnTraining(TrackToLearnTraining):

--- a/TrackToLearn/trainers/sac_auto_train.py
+++ b/TrackToLearn/trainers/sac_auto_train.py
@@ -7,6 +7,7 @@ from argparse import RawTextHelpFormatter
 import comet_ml  # noqa: F401 ugh
 import torch
 from comet_ml import Experiment as CometExperiment
+from comet_ml import OfflineExperiment as CometOfflineExperiment
 
 from TrackToLearn.algorithms.sac_auto import SACAuto
 from TrackToLearn.trainers.train import (TrackToLearnTraining,
@@ -100,11 +101,20 @@ def main():
     args = parse_args()
     print(args)
 
+    offline = args.comet_offline_dir is not None
+
     # Create comet-ml experiment
-    experiment = CometExperiment(project_name=args.experiment,
-                                 workspace=args.workspace, parse_args=False,
-                                 auto_metric_logging=False,
-                                 disabled=not args.use_comet)
+    if offline:
+        experiment = CometOfflineExperiment(project_name=args.experiment,
+                                    workspace=args.workspace, parse_args=False,
+                                    auto_metric_logging=False,
+                                    disabled=not args.use_comet,
+                                    offline_directory=args.comet_offline_dir)
+    else:
+        experiment = CometExperiment(project_name=args.experiment,
+                                    workspace=args.workspace, parse_args=False,
+                                    auto_metric_logging=False,
+                                    disabled=not args.use_comet)
 
     # Create and run experiment
     sac_auto_experiment = SACAutoTrackToLearnTraining(

--- a/TrackToLearn/trainers/sac_auto_train.py
+++ b/TrackToLearn/trainers/sac_auto_train.py
@@ -12,8 +12,8 @@ from comet_ml import OfflineExperiment as CometOfflineExperiment
 from TrackToLearn.algorithms.sac_auto import SACAuto
 from TrackToLearn.trainers.train import (TrackToLearnTraining,
                                          add_training_args)
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+from TrackToLearn.utils.torch_utils import get_device
+device = get_device()
 
 
 class SACAutoTrackToLearnTraining(TrackToLearnTraining):

--- a/TrackToLearn/trainers/sac_train.py
+++ b/TrackToLearn/trainers/sac_train.py
@@ -16,9 +16,9 @@ from TrackToLearn.experiment.experiment import (
 from TrackToLearn.experiment.train import (
     add_rl_args,
     TrackToLearnTraining)
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-assert torch.cuda.is_available()
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
+device = get_device()
+assert_accelerator()
 
 
 class SACTrackToLearnTraining(TrackToLearnTraining):

--- a/TrackToLearn/trainers/td3_train.py
+++ b/TrackToLearn/trainers/td3_train.py
@@ -16,9 +16,10 @@ from TrackToLearn.experiment.experiment import (
 from TrackToLearn.experiment.train import (
     add_rl_args,
     TrackToLearnTraining)
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-assert torch.cuda.is_available()
+device = get_device()
+assert_accelerator()
 
 
 class TD3TrackToLearnTraining(TrackToLearnTraining):

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -103,6 +103,7 @@ class TrackToLearnTraining(Experiment):
             "cuda" if torch.cuda.is_available() else "cpu")
 
         self.use_comet = train_dto['use_comet']
+        self.offline_comet = train_dto['offline_comet']
 
         # RNG
         torch.manual_seed(self.rng_seed)

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -154,7 +154,8 @@ class TrackToLearnTraining(Experiment):
         # These are added here because they are not known before
         self.hyperparameters.update({'input_size': self.input_size,
                                      'action_size': self.action_size,
-                                     'voxel_size': str(self.voxel_size)})
+                                     'voxel_size': str(self.voxel_size),
+                                     'target_sh_order': self.target_sh_order})
 
         directory = pjoin(self.experiment_path, "model")
         with open(
@@ -367,6 +368,8 @@ class TrackToLearnTraining(Experiment):
 
         # Voxel size
         self.voxel_size = env.get_voxel_size()
+        # SH Order (used for tracking afterwards)
+        self.target_sh_order = env.target_sh_order
 
         max_traj_length = env.max_nb_steps
 

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -21,6 +21,7 @@ from TrackToLearn.experiment.oracle_validator import OracleValidator
 from TrackToLearn.experiment.tractometer_validator import TractometerValidator
 from TrackToLearn.experiment.experiment import Experiment
 from TrackToLearn.tracking.tracker import Tracker
+from TrackToLearn.utils.torch_utils import get_device, assert_accelerator
 
 
 class TrackToLearnTraining(Experiment):
@@ -99,8 +100,8 @@ class TrackToLearnTraining(Experiment):
         self.comet_experiment = comet_experiment
         self.last_episode = 0
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
+        self.device = get_device()
+        
 
         self.use_comet = train_dto['use_comet']
 
@@ -353,8 +354,8 @@ class TrackToLearnTraining(Experiment):
         training loop
         """
 
-        assert torch.cuda.is_available(), \
-            "Training is only supported on CUDA devices."
+        assert_accelerator(), \
+            "Training is only supported with hardware accelerated devices."
 
         # Instantiate environment. Actions will be fed to it and new
         # states will be returned. The environment updates the streamline

--- a/TrackToLearn/trainers/train.py
+++ b/TrackToLearn/trainers/train.py
@@ -103,7 +103,6 @@ class TrackToLearnTraining(Experiment):
             "cuda" if torch.cuda.is_available() else "cpu")
 
         self.use_comet = train_dto['use_comet']
-        self.offline_comet = train_dto['offline_comet']
 
         # RNG
         torch.manual_seed(self.rng_seed)

--- a/TrackToLearn/utils/torch_utils.py
+++ b/TrackToLearn/utils/torch_utils.py
@@ -1,0 +1,15 @@
+import torch
+
+def get_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")
+    
+def assert_accelerator():
+    assert torch.cuda.is_available() or torch.backends.mps.is_available()
+
+def get_device_str():
+    return str(get_device())

--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,10 @@ if [ -x "$(command -v nvidia-smi)" ]; then
     echo "Found CUDA version: $(nvidia-smi | grep "CUDA Version" | awk '{print $9}')"
     # Check CUDA version and format as cuXXX
     FOUND_CUDA=$(nvidia-smi | grep "CUDA Version" | awk '{print $9}' | sed 's/\.//g')
-    if (( $FOUND_CUDA == 116 )); then
-        CUDA_VERSION="cu116"
-    elif (( $FOUND_CUDA >= 117 )); then
-        CUDA_VERSION="cu117"
+    if (( $FOUND_CUDA == 118 )); then
+        CUDA_VERSION="cu118"
+    elif (( $FOUND_CUDA >= 121 )); then
+        CUDA_VERSION="cu121"
     else
       CUDA_VERSION="cpu"
       echo "CUDA version ${FOUND_CUDA} is not compatible. Installing PyTorch without CUDA support."
@@ -29,13 +29,13 @@ echo "Installing required packages."
 pip install Cython==0.29.* numpy==1.23.* packaging --quiet
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Installing PyTorch 1.13.1"
-    pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 --quiet
+    echo "Installing PyTorch 2.2.0"
+    pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --quiet
 else
     # Install pytorch
-    echo "Installing PyTorch 1.13.1+${CUDA_VERSION}"
+    echo "Installing PyTorch 2.2.0+${CUDA_VERSION}"
     # Install PyTorch with CUDA support
-    pip install torch==1.13.1+${CUDA_VERSION} torchvision==0.14.1+${CUDA_VERSION} torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION} --quiet
+    pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION} --quiet
 fi
 
 # Install other required packages and modules

--- a/models/hyperparameters.json
+++ b/models/hyperparameters.json
@@ -47,5 +47,5 @@
     "input_size": 615,
     "action_size": 3,
     "voxel_size": "0.9987237",
-    "target_sh_order": 6.0
+    "target_sh_order": 8.0
 }

--- a/models/hyperparameters.json
+++ b/models/hyperparameters.json
@@ -46,5 +46,6 @@
     "replay_size": 1000000.0,
     "input_size": 615,
     "action_size": 3,
-    "voxel_size": "0.9987237"
+    "voxel_size": "0.9987237",
+    "target_sh_order": 6.0
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 comet-ml==3.39.0
-h5py==3.10.0
+h5py==3.7.0
 nibabel==5.2.0
-tqdm==4.66.4
+tqdm==4.64.0
 
-dwi-ml==0.1.0.dev0
+dwi-ml @ git+https://github.com/EmmaRenauld/dwi_ml.git@update_to_scilpy2
 scilpy==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-comet-ml==3.21.0
-h5py==3.7.0
-nibabel==4.0.2
-tqdm==4.64.1
+comet-ml==3.39.0
+h5py==3.10.0
+nibabel==5.2.0
+tqdm==4.66.4
 
-dwi-ml @ git+https://github.com/scil-vital/dwi_ml@b7ac03a5b4f2cab77bbcf000a763afa133786b04
-scilpy @ git+https://github.com/scilus/scilpy@1.5.0
+dwi-ml==0.1.0.dev0
+scilpy==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
-comet-ml==3.39.0
-h5py==3.7.0
-nibabel==5.2.0
-tqdm==4.64.0
-
-dwi-ml @ git+https://github.com/EmmaRenauld/dwi_ml.git@update_to_scilpy2
-scilpy==2.0.2
+dwi-ml @ git+https://github.com/scil-vital/dwi_ml@for_beluga_scilpy2


### PR DESCRIPTION
Should be merged after: https://github.com/scil-vital/TrackToLearn/pull/40

Allow the support of Metal Performance Shaders (MPS) backend to train on a Mac M1. Whilst this is not meant to perform a complete training (could still be possible), this is meant to at least be able to debug and run the training process without access to CUDA. 

I basically changed everything that was hardcoded "cuda" or "cuda:0" by utility functions so that we can add multiple backends easily. However, to actually use MPS to train a model, PyTorch 2.4.0 will be needed once it's out (there was a known bug that just got fixed). For now, we can just install a recent nighty build (torch==2.4.0.dev20240520, torchaudio==2.2.0.dev20240520, torchvision==0.19.0.dev20240520. With index: https://download.pytorch.org/whl/nightly/) manually and everything should work fine.

So: ```pip install torch==2.4.0.dev20240520 torchaudio==2.2.0.dev20240520 torchvision==0.19.0.dev20240520 --index=https://download.pytorch.org/whl/nightly/```

I propose we merge this to support MPS everywhere in the code and so it's available for all subsequent branches, and if we want to use it locally we can just install the torch nightly build.

I'll take note of upgrading to torch 2.4.0 once the official release is out in late July.